### PR TITLE
Add issue transfer UI with repo selection

### DIFF
--- a/src/main/java/com/jaoafa/feedback/Main.java
+++ b/src/main/java/com/jaoafa/feedback/Main.java
@@ -46,6 +46,8 @@ public class Main {
                             new ImprovementMenuSubmitEvent(),
                             new ChangeTitleSubmitEvent(),
                             new SendToIssueEvent(),
+                            new TransferIssueEvent(),
+                            new TransferIssueSelectEvent(),
                             new CloseReportEvent(),
                             new ThreadButtonEvent())
                     .build()

--- a/src/main/java/com/jaoafa/feedback/event/ThreadButtonEvent.java
+++ b/src/main/java/com/jaoafa/feedback/event/ThreadButtonEvent.java
@@ -3,18 +3,24 @@ package com.jaoafa.feedback.event;
 import com.jaoafa.feedback.Main;
 import com.jaoafa.feedback.lib.Config;
 import com.jaoafa.feedback.lib.FeedbackManager;
+import com.jaoafa.feedback.lib.GitHub;
 import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.channel.concrete.ThreadChannel;
 import net.dv8tion.jda.api.entities.channel.unions.MessageChannelUnion;
 import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
+import net.dv8tion.jda.api.components.actionrow.ActionRow;
 import net.dv8tion.jda.api.components.label.Label;
+import net.dv8tion.jda.api.components.selections.StringSelectMenu;
+import net.dv8tion.jda.api.components.selections.SelectOption;
 import net.dv8tion.jda.api.components.textinput.TextInput;
 import net.dv8tion.jda.api.components.textinput.TextInputStyle;
 import net.dv8tion.jda.api.modals.Modal;
 import net.dv8tion.jda.internal.utils.PermissionUtil;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 
 public class ThreadButtonEvent extends ListenerAdapter {
@@ -46,6 +52,10 @@ public class ThreadButtonEvent extends ListenerAdapter {
         if (event.getComponentId().equals("send-to-issue")) {
             // GitHub Issueにメッセージを送信
             actionSendToIssue(event, thread);
+        }
+        if (event.getComponentId().equals("transfer-issue")) {
+            // GitHub Issueを移動
+            actionTransferIssue(event, thread);
         }
         if (event.getComponentId().equals("close-report")) {
             // Reportをクローズ
@@ -106,6 +116,71 @@ public class ThreadButtonEvent extends ListenerAdapter {
                         .addComponents(Label.of("メッセージ", messageRow))
                         .build())
                 .queue();
+    }
+
+    void actionTransferIssue(ButtonInteractionEvent event, ThreadChannel thread) {
+        if (thread.isLocked()) {
+            event.reply("このスレッドはすでにロックされています。").setEphemeral(true).queue();
+            return;
+        }
+        if (!PermissionUtil.checkPermission(thread.getPermissionContainer(),
+                Objects.requireNonNull(event.getMember()),
+                Permission.MANAGE_THREADS)) {
+            event.reply("あなたにはこのアクションを実行する権限がありません。").setEphemeral(true).queue();
+            return;
+        }
+
+        FeedbackManager.transferIssueMap.put(event.getUser().getIdLong(), thread);
+
+        String owner = getDefaultOwner();
+        GitHub.ListRepositoriesResult repositoriesResult = GitHub.listOrganizationRepositories(owner, 15);
+        List<SelectOption> options = new ArrayList<>();
+        if (repositoriesResult.repositories() != null) {
+            for (String repository : repositoriesResult.repositories()) {
+                String label = repository;
+                String ownerPrefix = owner + "/";
+                if (repository.startsWith(ownerPrefix)) {
+                    label = repository.substring(ownerPrefix.length());
+                }
+                options.add(SelectOption.of(label, repository));
+            }
+        }
+
+        if (repositoriesResult.error() != null || options.isEmpty()) {
+            TextInput repositoryRow = TextInput
+                    .create("repository", TextInputStyle.SHORT)
+                    .setPlaceholder("一覧取得に失敗したため手入力してください (repo または owner/repo)")
+                    .setMinLength(3)
+                    .setMaxLength(200)
+                    .setRequired(true)
+                    .build();
+
+            event.replyModal(Modal.create("transfer-issue", "Issueを移動")
+                            .addComponents(Label.of("移動先リポジトリ（一覧取得に失敗）", repositoryRow))
+                            .build())
+                    .queue();
+            return;
+        }
+        options.add(SelectOption.of("その他", "__manual__").withDescription("手入力する"));
+
+        StringSelectMenu menu = StringSelectMenu.create("transfer-issue-select")
+                .setPlaceholder("移動先リポジトリを選択")
+                .setMinValues(1)
+                .setMaxValues(1)
+                .addOptions(options)
+                .build();
+
+        event.replyComponents(ActionRow.of(menu))
+                .setEphemeral(true)
+                .queue();
+    }
+
+    private String getDefaultOwner() {
+        String repository = Main.getConfig().getRepository();
+        if (repository != null && repository.contains("/")) {
+            return repository.split("/", 2)[0];
+        }
+        return "jaoafa";
     }
 
     void actionCloseReport(ButtonInteractionEvent event, ThreadChannel thread) {

--- a/src/main/java/com/jaoafa/feedback/event/TransferIssueEvent.java
+++ b/src/main/java/com/jaoafa/feedback/event/TransferIssueEvent.java
@@ -1,0 +1,151 @@
+package com.jaoafa.feedback.event;
+
+import com.jaoafa.feedback.Main;
+import com.jaoafa.feedback.lib.FeedbackManager;
+import com.jaoafa.feedback.lib.GitHub;
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.entities.User;
+import net.dv8tion.jda.api.entities.channel.concrete.ThreadChannel;
+import net.dv8tion.jda.api.events.interaction.ModalInteractionEvent;
+import net.dv8tion.jda.api.hooks.ListenerAdapter;
+
+import java.awt.*;
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class TransferIssueEvent extends ListenerAdapter {
+    private static final Pattern OWNER_REPO_PATTERN = Pattern.compile("^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$");
+    private static final Pattern REPO_PATTERN = Pattern.compile("^[A-Za-z0-9_.-]+$");
+
+    @Override
+    public void onModalInteraction(ModalInteractionEvent event) {
+        if (event.getGuild() == null || event.getGuild().getIdLong() != Main.getConfig().getGuildId()) {
+            event.reply("このサーバでは利用できません。").setEphemeral(true).queue();
+            return;
+        }
+        if (!event.getModalId().equals("transfer-issue")) {
+            return;
+        }
+
+        String rawTarget = Objects.requireNonNull(event.getValue("repository")).getAsString().trim();
+        String targetRepository = normalizeTargetRepository(rawTarget);
+        if (targetRepository == null) {
+            event.reply("移動先リポジトリの形式が正しくありません。`repo` または `owner/repo` で指定してください。").setEphemeral(true).queue();
+            return;
+        }
+
+        User user = event.getUser();
+        ThreadChannel thread = FeedbackManager.transferIssueMap.get(user.getIdLong());
+        if (thread == null) {
+            event.reply("対象スレッドを見つけられませんでした。もう一度お試しください。").queue();
+            return;
+        }
+        FeedbackManager.transferIssueMap.remove(user.getIdLong());
+
+        TransferOutcome outcome = transferIssue(user, thread, targetRepository);
+        if (!outcome.success()) {
+            event.reply(outcome.errorMessage()).setEphemeral(true).queue();
+            return;
+        }
+
+        event.deferEdit().queue();
+    }
+
+    public static TransferOutcome transferIssue(User user, ThreadChannel thread, String targetRepository) {
+        int issueNumber = -1;
+        String prevTitle = thread.getName();
+        Matcher matcher = FeedbackManager.ISSUE_PATTERN.matcher(prevTitle);
+        if (matcher.find()) {
+            issueNumber = Integer.parseInt(matcher.group(1));
+        }
+        if (issueNumber == -1) {
+            return new TransferOutcome(false, "Issue番号が見つかりませんでした。");
+        }
+
+        FeedbackManager feedbackManager = new FeedbackManager();
+        String repository = Main.getConfig().getRepository();
+        FeedbackManager.Feedback feedback = feedbackManager.getFeedbackByThreadId(thread.getIdLong());
+        if (feedback != null && feedback.repository() != null) {
+            repository = feedback.repository();
+        }
+        String originalRepository = repository;
+
+        GitHub.ResolveIssueResult resolved = GitHub.resolveIssue(repository, issueNumber);
+        if (resolved.error() != null) {
+            String errorResult = trimError(resolved.error(), 100);
+            return new TransferOutcome(false, "GitHub Issue の解決に失敗しました: ```%s```".formatted(errorResult));
+        }
+        if (resolved.repository() != null) {
+            repository = resolved.repository();
+        }
+        if (resolved.issueNumber() != issueNumber || (resolved.repository() != null && !resolved.repository().equals(originalRepository))) {
+            String baseTitle = thread.getName().replaceFirst("^\\*\\d+ ", "");
+            thread.getManager().setName("*%d %s".formatted(resolved.issueNumber(), baseTitle)).queue();
+            feedbackManager.updateFeedbackIssue(thread.getIdLong(), repository, resolved.issueNumber());
+        }
+        issueNumber = resolved.issueNumber();
+
+        if (resolved.nodeId() == null) {
+            return new TransferOutcome(false, "Issue ID の取得に失敗しました。しばらくしてから再試行してください。");
+        }
+        if (repository != null && repository.equalsIgnoreCase(targetRepository)) {
+            return new TransferOutcome(false, "移動先が現在のリポジトリと同一です。");
+        }
+
+        GitHub.TransferIssueResult transferResult = GitHub.transferIssue(resolved.nodeId(), targetRepository, false);
+        if (transferResult.error() != null) {
+            String errorResult = trimError(transferResult.error(), 150);
+            return new TransferOutcome(false, "Issue の移動に失敗しました: ```%s```".formatted(errorResult));
+        }
+        if (transferResult.issueNumber() == null) {
+            return new TransferOutcome(false, "Issue の移動結果を取得できませんでした。");
+        }
+
+        String baseTitle = thread.getName().replaceFirst("^\\*\\d+ ", "");
+        String newRepository = transferResult.repository() != null ? transferResult.repository() : targetRepository;
+        thread.getManager().setName("*%d %s".formatted(transferResult.issueNumber(), baseTitle)).queue();
+        feedbackManager.updateFeedbackIssue(thread.getIdLong(), newRepository, transferResult.issueNumber());
+
+        thread.sendMessageEmbeds(
+                new EmbedBuilder()
+                        .setTitle("Issueを移動しました")
+                        .addField("移動先", newRepository, false)
+                        .addField("URL", transferResult.htmlUrl() != null ? transferResult.htmlUrl() : "N/A", false)
+                        .setAuthor(user.getName(), "https://discord.com/users/%s".formatted(user.getId()), user.getAvatarUrl())
+                        .setColor(Color.GREEN)
+                        .setFooter("GitHub Issue を移動")
+                        .build()
+        ).queue();
+
+        return new TransferOutcome(true, null);
+    }
+
+    private static String normalizeTargetRepository(String targetRepository) {
+        if (OWNER_REPO_PATTERN.matcher(targetRepository).matches()) {
+            return targetRepository;
+        }
+        if (REPO_PATTERN.matcher(targetRepository).matches()) {
+            return getDefaultOwner() + "/" + targetRepository;
+        }
+        return null;
+    }
+
+    private static String getDefaultOwner() {
+        String repository = Main.getConfig().getRepository();
+        if (repository != null && repository.contains("/")) {
+            return repository.split("/", 2)[0];
+        }
+        return "jaoafa";
+    }
+
+    private static String trimError(String error, int maxLength) {
+        if (error == null) {
+            return "";
+        }
+        return error.length() > maxLength ? error.substring(0, maxLength) + "..." : error;
+    }
+
+    public record TransferOutcome(boolean success, String errorMessage) {
+    }
+}

--- a/src/main/java/com/jaoafa/feedback/event/TransferIssueSelectEvent.java
+++ b/src/main/java/com/jaoafa/feedback/event/TransferIssueSelectEvent.java
@@ -1,0 +1,65 @@
+package com.jaoafa.feedback.event;
+
+import com.jaoafa.feedback.Main;
+import com.jaoafa.feedback.lib.FeedbackManager;
+import net.dv8tion.jda.api.entities.User;
+import net.dv8tion.jda.api.entities.channel.concrete.ThreadChannel;
+import net.dv8tion.jda.api.events.interaction.component.StringSelectInteractionEvent;
+import net.dv8tion.jda.api.hooks.ListenerAdapter;
+import net.dv8tion.jda.api.components.label.Label;
+import net.dv8tion.jda.api.components.textinput.TextInput;
+import net.dv8tion.jda.api.components.textinput.TextInputStyle;
+import net.dv8tion.jda.api.modals.Modal;
+
+public class TransferIssueSelectEvent extends ListenerAdapter {
+    private static final String MANUAL_VALUE = "__manual__";
+
+    @Override
+    public void onStringSelectInteraction(StringSelectInteractionEvent event) {
+        if (event.getGuild() == null || event.getGuild().getIdLong() != Main.getConfig().getGuildId()) {
+            event.reply("このサーバでは利用できません。").setEphemeral(true).queue();
+            return;
+        }
+        if (!event.getComponentId().equals("transfer-issue-select")) {
+            return;
+        }
+        if (event.getValues().isEmpty()) {
+            event.reply("移動先リポジトリを選択してください。").setEphemeral(true).queue();
+            return;
+        }
+
+        User user = event.getUser();
+        ThreadChannel thread = FeedbackManager.transferIssueMap.get(user.getIdLong());
+        if (thread == null) {
+            event.reply("対象スレッドを見つけられませんでした。もう一度お試しください。").queue();
+            return;
+        }
+
+        String selected = event.getValues().get(0);
+        if (MANUAL_VALUE.equals(selected)) {
+            TextInput repositoryRow = TextInput
+                    .create("repository", TextInputStyle.SHORT)
+                    .setPlaceholder("移動先リポジトリ (repo または owner/repo)")
+                    .setMinLength(3)
+                    .setMaxLength(200)
+                    .setRequired(true)
+                    .build();
+
+            event.replyModal(Modal.create("transfer-issue", "Issueを移動")
+                            .addComponents(Label.of("移動先リポジトリ", repositoryRow))
+                            .build())
+                    .queue();
+            return;
+        }
+
+        FeedbackManager.transferIssueMap.remove(user.getIdLong());
+
+        TransferIssueEvent.TransferOutcome outcome = TransferIssueEvent.transferIssue(user, thread, selected);
+        if (!outcome.success()) {
+            event.reply(outcome.errorMessage()).setEphemeral(true).queue();
+            return;
+        }
+
+        event.deferEdit().queue();
+    }
+}

--- a/src/main/java/com/jaoafa/feedback/lib/FeedbackManager.java
+++ b/src/main/java/com/jaoafa/feedback/lib/FeedbackManager.java
@@ -26,6 +26,7 @@ public class FeedbackManager {
     public static final Map<Long, Message> messageMap = new HashMap<>();
     public static final Map<Long, ThreadChannel> changeTitleMap = new HashMap<>();
     public static final Map<Long, ThreadChannel> sendToIssueMap = new HashMap<>();
+    public static final Map<Long, ThreadChannel> transferIssueMap = new HashMap<>();
     public static final Map<Long, ThreadChannel> closeReportMap = new HashMap<>();
     public static final Pattern ISSUE_PATTERN = Pattern.compile("^\\*(\\d+) ");
     private final Path FEEDBACKS_PATH;

--- a/src/main/java/com/jaoafa/feedback/lib/FeedbackModel.java
+++ b/src/main/java/com/jaoafa/feedback/lib/FeedbackModel.java
@@ -123,6 +123,8 @@ public class FeedbackModel {
                         .withEmoji(Emoji.fromUnicode("\uD83D\uDD04")),
                 Button.primary("send-to-issue", "Issueにメッセージを送信")
                         .withEmoji(Emoji.fromUnicode("\uD83D\uDCAC")),
+                Button.primary("transfer-issue", "Issueを移動")
+                        .withEmoji(Emoji.fromUnicode("\uD83D\uDCE6")),
                 Button.danger("close-report", "リクエスト/報告をクローズ")
                         .withEmoji(Emoji.fromUnicode("\uD83D\uDD10")));
     }

--- a/src/main/java/com/jaoafa/feedback/lib/GitHub.java
+++ b/src/main/java/com/jaoafa/feedback/lib/GitHub.java
@@ -8,6 +8,7 @@ import org.json.JSONObject;
 
 import java.io.IOException;
 import java.net.URI;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
@@ -109,18 +110,19 @@ public class GitHub {
                     ResponseBody result = response.body();
                     String details = result != null ? result.string() : "";
                     Main.getLogger().error("GitHub.resolveIssue: " + details);
-                    return new ResolveIssueResult(null, -1, null, details);
+                    return new ResolveIssueResult(null, -1, null, null, details);
                 }
 
                 ResponseBody responseBody = response.body();
                 if (responseBody == null) {
                     String details = "Empty response body";
                     Main.getLogger().error("GitHub.resolveIssue: " + details);
-                    return new ResolveIssueResult(null, -1, null, details);
+                    return new ResolveIssueResult(null, -1, null, null, details);
                 }
                 JSONObject obj = new JSONObject(responseBody.string());
                 int resolvedIssueNumber = obj.getInt("number");
                 String htmlUrl = obj.optString("html_url", null);
+                String nodeId = obj.optString("node_id", null);
 
                 String resolvedRepo = null;
                 HttpUrl finalUrl = response.request().url();
@@ -140,14 +142,14 @@ public class GitHub {
                     }
                 }
 
-                return new ResolveIssueResult(resolvedRepo, resolvedIssueNumber, htmlUrl, null);
+                return new ResolveIssueResult(resolvedRepo, resolvedIssueNumber, htmlUrl, nodeId, null);
             }
         } catch (IOException e) {
-            return new ResolveIssueResult(null, -1, null, e.getClass().getName() + " " + e.getMessage());
+            return new ResolveIssueResult(null, -1, null, null, e.getClass().getName() + " " + e.getMessage());
         }
     }
 
-    public record ResolveIssueResult(String repository, int issueNumber, String htmlUrl, String error) {
+    public record ResolveIssueResult(String repository, int issueNumber, String htmlUrl, String nodeId, String error) {
     }
 
     public static UpdateIssueResult updateIssue(String repo, int issueNum, UpdateType type, Object value) {
@@ -181,6 +183,179 @@ public class GitHub {
     }
 
     public record UpdateIssueResult(String error) {
+    }
+
+    public static ListRepositoriesResult listOrganizationRepositories(String organization, int limit) {
+        if (limit <= 0) {
+            return new ListRepositoriesResult(List.of(), "Invalid limit");
+        }
+        int perPage = Math.min(limit, 100);
+        String githubToken = Main.getConfig().getGitHubAPIToken();
+        String url = String.format("https://api.github.com/orgs/%s/repos?per_page=%d&sort=updated&direction=desc", organization, perPage);
+
+        try {
+            OkHttpClient client = new OkHttpClient();
+            Request request = new Request.Builder()
+                    .url(url)
+                    .header("Authorization", String.format("token %s", githubToken))
+                    .get()
+                    .build();
+            try (Response response = client.newCall(request).execute()) {
+                ResponseBody responseBody = response.body();
+                String body = responseBody != null ? responseBody.string() : "";
+                if (response.code() != 200) {
+                    Main.getLogger().error("GitHub.listOrganizationRepositories: " + body);
+                    return new ListRepositoriesResult(List.of(), body.isEmpty() ? "Unexpected status: " + response.code() : body);
+                }
+                JSONArray array = new JSONArray(body);
+                List<String> repositories = new ArrayList<>();
+                for (int i = 0; i < array.length(); i++) {
+                    JSONObject obj = array.optJSONObject(i);
+                    if (obj == null) {
+                        continue;
+                    }
+                    String fullName = obj.optString("full_name", null);
+                    if (fullName != null && !fullName.isEmpty()) {
+                        repositories.add(fullName);
+                    }
+                }
+                return new ListRepositoriesResult(repositories, null);
+            }
+        } catch (IOException e) {
+            return new ListRepositoriesResult(List.of(), e.getClass().getName() + " " + e.getMessage());
+        }
+    }
+
+    public record ListRepositoriesResult(List<String> repositories, String error) {
+    }
+
+    public static RepositoryNodeIdResult getRepositoryNodeId(String repo) {
+        String githubToken = Main.getConfig().getGitHubAPIToken();
+        String url = String.format("https://api.github.com/repos/%s", repo);
+
+        try {
+            OkHttpClient client = new OkHttpClient();
+            Request request = new Request.Builder()
+                    .url(url)
+                    .header("Authorization", String.format("token %s", githubToken))
+                    .get()
+                    .build();
+            try (Response response = client.newCall(request).execute()) {
+                if (response.code() != 200) {
+                    ResponseBody result = response.body();
+                    String details = result != null ? result.string() : "";
+                    Main.getLogger().error("GitHub.getRepositoryNodeId: " + details);
+                    return new RepositoryNodeIdResult(null, details);
+                }
+
+                ResponseBody responseBody = response.body();
+                if (responseBody == null) {
+                    String details = "Empty response body";
+                    Main.getLogger().error("GitHub.getRepositoryNodeId: " + details);
+                    return new RepositoryNodeIdResult(null, details);
+                }
+                JSONObject obj = new JSONObject(responseBody.string());
+                String nodeId = obj.optString("node_id", null);
+                if (nodeId == null || nodeId.isEmpty()) {
+                    String details = "Empty repository node_id";
+                    Main.getLogger().error("GitHub.getRepositoryNodeId: " + details);
+                    return new RepositoryNodeIdResult(null, details);
+                }
+                return new RepositoryNodeIdResult(nodeId, null);
+            }
+        } catch (IOException e) {
+            return new RepositoryNodeIdResult(null, e.getClass().getName() + " " + e.getMessage());
+        }
+    }
+
+    public record RepositoryNodeIdResult(String nodeId, String error) {
+    }
+
+    public static TransferIssueResult transferIssue(String issueNodeId, String targetRepository, boolean createLabelsIfMissing) {
+        RepositoryNodeIdResult repositoryNodeIdResult = getRepositoryNodeId(targetRepository);
+        if (repositoryNodeIdResult.error() != null) {
+            return new TransferIssueResult(null, null, null, repositoryNodeIdResult.error());
+        }
+
+        JSONObject variables = new JSONObject()
+                .put("issueId", issueNodeId)
+                .put("repositoryId", repositoryNodeIdResult.nodeId())
+                .put("createLabelsIfMissing", createLabelsIfMissing);
+        String query = "mutation($issueId: ID!, $repositoryId: ID!, $createLabelsIfMissing: Boolean!) {"
+                + " transferIssue(input: {issueId: $issueId, repositoryId: $repositoryId, createLabelsIfMissing: $createLabelsIfMissing}) {"
+                + " issue { number url repository { nameWithOwner } }"
+                + " }"
+                + "}";
+        JSONObject payload = new JSONObject()
+                .put("query", query)
+                .put("variables", variables);
+
+        String githubToken = Main.getConfig().getGitHubAPIToken();
+        try {
+            OkHttpClient client = new OkHttpClient();
+            RequestBody requestBody = RequestBody.create(payload.toString(),
+                    MediaType.parse("application/json; charset=UTF-8"));
+            Request request = new Request.Builder()
+                    .url("https://api.github.com/graphql")
+                    .header("Authorization", String.format("token %s", githubToken))
+                    .post(requestBody)
+                    .build();
+            try (Response response = client.newCall(request).execute()) {
+                ResponseBody responseBody = response.body();
+                String body = responseBody != null ? responseBody.string() : "";
+                if (response.code() != 200) {
+                    Main.getLogger().error("GitHub.transferIssue: " + body);
+                    return new TransferIssueResult(null, null, null, body.isEmpty() ? "Unexpected status: " + response.code() : body);
+                }
+                JSONObject obj = new JSONObject(body);
+                if (obj.has("errors")) {
+                    JSONArray errors = obj.getJSONArray("errors");
+                    StringBuilder detailsBuilder = new StringBuilder();
+                    for (int i = 0; i < errors.length(); i++) {
+                        JSONObject error = errors.optJSONObject(i);
+                        String message = error != null ? error.optString("message", error.toString()) : errors.get(i).toString();
+                        if (detailsBuilder.length() != 0) {
+                            detailsBuilder.append("\n");
+                        }
+                        detailsBuilder.append(message);
+                    }
+                    String details = detailsBuilder.length() == 0 ? "Unknown error" : detailsBuilder.toString();
+                    Main.getLogger().error("GitHub.transferIssue: " + details);
+                    return new TransferIssueResult(null, null, null, details);
+                }
+                JSONObject data = obj.optJSONObject("data");
+                if (data == null) {
+                    String details = "Empty data in GraphQL response";
+                    Main.getLogger().error("GitHub.transferIssue: " + details);
+                    return new TransferIssueResult(null, null, null, details);
+                }
+                JSONObject transfer = data.optJSONObject("transferIssue");
+                if (transfer == null) {
+                    String details = "Empty transferIssue in GraphQL response";
+                    Main.getLogger().error("GitHub.transferIssue: " + details);
+                    return new TransferIssueResult(null, null, null, details);
+                }
+                JSONObject issue = transfer.optJSONObject("issue");
+                if (issue == null) {
+                    String details = "Empty issue in GraphQL response";
+                    Main.getLogger().error("GitHub.transferIssue: " + details);
+                    return new TransferIssueResult(null, null, null, details);
+                }
+                int issueNumber = issue.getInt("number");
+                String htmlUrl = issue.optString("url", null);
+                String repository = null;
+                JSONObject repositoryObj = issue.optJSONObject("repository");
+                if (repositoryObj != null) {
+                    repository = repositoryObj.optString("nameWithOwner", null);
+                }
+                return new TransferIssueResult(issueNumber, repository, htmlUrl, null);
+            }
+        } catch (IOException e) {
+            return new TransferIssueResult(null, null, null, e.getClass().getName() + " " + e.getMessage());
+        }
+    }
+
+    public record TransferIssueResult(Integer issueNumber, String repository, String htmlUrl, String error) {
     }
 
     public enum UpdateType {


### PR DESCRIPTION
- close #64

## 概要
Issue を別リポジトリへ移動できるボタンを追加し、移動先を選択または手入力できるようにしました。移動後はスレッド名と保存済みの repository/issueNumber を新しい値へ更新します。

## 変更内容（具体）
- スレッドの操作ボタンに「Issueを移動」を追加
- 移動先の選択 UI を追加（jaoafa の最新15リポジトリを毎回取得してセレクト表示）
- 一覧取得に失敗した場合は自動で手入力モーダルを表示
- 「その他」選択時は `repo` または `owner/repo` の手入力を許可（`repo` の場合はデフォルト owner を補完）
- GitHub GraphQL の `transferIssue` を実装し、移動処理を実行
- Issue解決失敗や移動失敗時のエラーメッセージを表示

## 動作イメージ
1. 「Issueを移動」を押す
2. 移動先リポジトリを選択（または「その他」から手入力）
3. Issue を移動し、スレッド名とリンク先を更新

## テスト
- 未実施（mvn が実行環境に存在しなかったため）
